### PR TITLE
Add Juju dev docs

### DIFF
--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -56,6 +56,9 @@
               <a href="/docs/sdk" class="p-navigation__dropdown-item">Charmed Operator SDK</a>
             </li>
             <li>
+              <a href="/docs/dev" class="p-navigation__dropdown-item">Developers</a>
+            </li>
+            <li>
               <a href="/tutorials" class="p-navigation__dropdown-item">Tutorials</a>
             </li>
             <li>

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -102,3 +102,23 @@ def init_docs(app):
             template_path="docs/search.html",
         ),
     )
+
+    juju_dev_docs_id = 6669
+    juju_dev_docs = Docs(
+        parser=DocParser(
+            api=DiscourseAPI(
+                base_url="https://discourse.charmhub.io/",
+                session=session,
+                api_key=DISCOURSE_API_KEY,
+                api_username=DISCOURSE_API_USERNAME,
+                get_topics_query_id=2,
+            ),
+            index_topic_id=juju_dev_docs_id,
+            url_prefix="/docs/dev",
+        ),
+        document_template="docs/document.html",
+        url_prefix="/docs/dev",
+        blueprint_name="juju_dev_docs",
+    )
+
+    juju_dev_docs.init_app(app)


### PR DESCRIPTION
## Done

Add Juju developer docs according to https://github.com/canonical/juju.is/issues/428

## QA

- Go to https://juju-is-430.demos.haus/docs and click on the juju dev docs, check that the documentation renders correctly according to the index topic https://discourse.charmhub.io/t/juju-developers-documentation/6669
- Go to top right navigation -> click Learn -> click on Juju developers and do the same review.


## Issue / Card

Fixes https://github.com/canonical/juju.is/issues/428
