### PR TITLE
Update side navigation to new expandable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "stylelint-config-recommended-scss": "5.0.2",
     "stylelint-order": "5.0.0",
     "stylelint-prettier": "2.0.0",
-    "vanilla-framework": "3.5.0",
+    "vanilla-framework": "3.7.0",
     "watch-cli": "0.2.3"
   }
 }

--- a/static/js/docs-side-nav.js
+++ b/static/js/docs-side-nav.js
@@ -1,0 +1,160 @@
+(function () {
+  /**
+  Toggles the expanded/collapsed classed on side navigation element.
+
+  @param {HTMLElement} sideNavigation The side navigation element.
+  @param {Boolean} show Whether to show or hide the drawer.
+*/
+  function toggleDrawer(sideNavigation, show) {
+    const toggleButtonOutsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle"
+    );
+    const toggleButtonInsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle--in-drawer"
+    );
+
+    if (sideNavigation) {
+      if (show) {
+        sideNavigation.classList.remove("is-drawer-collapsed");
+        sideNavigation.classList.add("is-drawer-expanded");
+
+        toggleButtonInsideDrawer.focus();
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", true);
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", true);
+      } else {
+        sideNavigation.classList.remove("is-drawer-expanded");
+        sideNavigation.classList.add("is-drawer-collapsed");
+
+        toggleButtonOutsideDrawer.focus();
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", false);
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", false);
+      }
+    }
+  }
+
+  // throttle util (for window resize event)
+  var throttle = function (fn, delay) {
+    var timer = null;
+    return function () {
+      var context = this,
+        args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function () {
+        fn.apply(context, args);
+      }, delay);
+    };
+  };
+
+  /**
+    Attaches event listeners for the side navigation toggles
+    @param {HTMLElement} sideNavigation The side navigation element.
+  */
+  function setupSideNavigation(sideNavigation) {
+    var toggles = [].slice.call(
+      sideNavigation.querySelectorAll(".js-drawer-toggle")
+    );
+    var drawerEl = sideNavigation.querySelector(".p-side-navigation__drawer");
+
+    // hide navigation drawer on small screens
+    sideNavigation.classList.add("is-drawer-hidden");
+
+    // setup drawer element
+    drawerEl.addEventListener("animationend", () => {
+      if (!sideNavigation.classList.contains("is-drawer-expanded")) {
+        sideNavigation.classList.add("is-drawer-hidden");
+      }
+    });
+
+    window.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        toggleDrawer(sideNavigation, false);
+      }
+    });
+
+    // setup toggle buttons
+    toggles.forEach(function (toggle) {
+      toggle.addEventListener("click", function (event) {
+        event.preventDefault();
+
+        if (sideNavigation) {
+          sideNavigation.classList.remove("is-drawer-hidden");
+          toggleDrawer(
+            sideNavigation,
+            !sideNavigation.classList.contains("is-drawer-expanded")
+          );
+        }
+      });
+    });
+
+    // hide side navigation drawer when screen is resized
+    window.addEventListener(
+      "resize",
+      throttle(function () {
+        toggles.forEach((toggle) => {
+          return toggle.setAttribute("aria-expanded", false);
+        });
+        // remove expanded/collapsed class names to avoid unexpected animations
+        sideNavigation.classList.remove("is-drawer-expanded");
+        sideNavigation.classList.remove("is-drawer-collapsed");
+        sideNavigation.classList.add("is-drawer-hidden");
+      }, 10)
+    );
+  }
+
+  /**
+    Attaches event listeners for all the side navigations in the document.
+    @param {String} sideNavigationSelector The CSS selector matching side navigation elements.
+  */
+  function setupSideNavigations(sideNavigationSelector) {
+    // Setup all side navigations on the page.
+    var sideNavigations = [].slice.call(
+      document.querySelectorAll(sideNavigationSelector)
+    );
+
+    sideNavigations.forEach(setupSideNavigation);
+  }
+
+  setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
+
+  // Setup expandable side navigation
+
+  var expandToggles = document.querySelectorAll(".p-side-navigation__expand");
+  var navigationLinks = document.querySelectorAll(".p-side-navigation__link");
+
+  // setup default values of aria-expanded for the toggle button, list title and list itself
+  const setup = (toggle) => {
+    const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+    if (!isExpanded) {
+      toggle.setAttribute("aria-expanded", isExpanded);
+    }
+    const item = toggle.closest(".p-side-navigation__item");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    if (!link?.hasAttribute("aria-expanded")) {
+      link.setAttribute("aria-expanded", isExpanded);
+    }
+    if (!nestedList?.hasAttribute("aria-expanded")) {
+      nestedList.setAttribute("aria-expanded", isExpanded);
+    }
+  };
+
+  const handleToggle = (e) => {
+    const item = e.currentTarget.closest(".p-side-navigation__item");
+    const button = item.querySelector(".p-side-navigation__expand");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    [button, link, nestedList].forEach((el) =>
+      el.setAttribute(
+        "aria-expanded",
+        el.getAttribute("aria-expanded") === "true" ? "false" : "true"
+      )
+    );
+  };
+
+  expandToggles.forEach((toggle) => {
+    setup(toggle);
+    toggle.addEventListener("click", (e) => {
+      handleToggle(e);
+    });
+  });
+})();

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -1,29 +1,33 @@
 {% extends "docs/base.html" %}
 
 {% block content_docs %}
-{% macro create_navigation(nav_items, expandable=False) %}
+{% macro create_navigation(nav_items, expandable=False, expanded=False) %}
   <ul class="p-side-navigation__list">
     {% for element in nav_items %}
     <li class="p-side-navigation__item">
       {% if element.navlink_href %}
-      <a class="p-side-navigation__link" href="{{ element.navlink_href }}"
+      <a
+        class="p-side-navigation__link {% if expandable and element.children %}is-expandable{% endif %}"
+        href="{{ element.navlink_href }}"
+        {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
         {% if element.is_active %}aria-current="page"{% endif %}
       >{{ element.navlink_text }}</a>
       {% else %}
-        <strong class="p-side-navigation__text">{{ element.navlink_text }}</strong>
+        <strong
+          class="p-side-navigation__text {% if expandable and element.children %}is-expandable{% endif %}"
+          {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
+          {% if element.is_active %}aria-current="page"{% endif %}
+        >{{ element.navlink_text }}</strong>
       {% endif %}
 
       {% if expandable %}
-        {% if element.navlink_href %}
-          {% if element.children and (element.is_active or element.has_active_child) %}
-            {{ create_navigation(element.children, True) }}
-          {% endif %}
-        {% else %}
-          {{ create_navigation(element.children, True) }}
+        {% if element.children %}
+            <button class="p-side-navigation__expand" aria-expanded={% if element.is_active or element.has_active_child %}"true"{% else %}"false"{% endif %} aria-label="show submenu for {{ element.navlink_text }}"></button>
         {% endif %}
+        {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}
       {% else %}
         {% if element.children %}
-          {{ create_navigation(element.children, False) }}
+          {{ create_navigation(element.children, expandable) }}
         {% endif %}
       {% endif %}
     </li>
@@ -95,4 +99,5 @@
 </section>
 
 <script src="{{ versioned_static('js/prism.js') }}"></script>
+<script src="{{ versioned_static('js/docs-side-nav.js') }}"></script>
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,11 @@
   resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-1.3.0.tgz#14fcd8a80051eb65fb274a0cec086e9aca3f19f0"
   integrity sha512-VwGcZo9LGzdeQ/sKt+5TQttIibTxjZEpsEtuWbbsacbqqzqVfqZhDsZkkg/7WNxKQ2lpnyq+4mLT70u9YbYSYA==
 
+"@canonical/latest-news@1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-1.4.1.tgz#dcdd445ac2268a54cf60f2f8c725b6bdeb285d71"
+  integrity sha512-lwrikCj0Y11X8Ln8D+elp6Ri3mYjMjsAOJtadNEFzhBrgmg8TVGYJjOdwy8TvRaxy7fHnvVajIKAYWX44Tfj6w==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz"
@@ -171,6 +176,18 @@ autoprefixer@10.4.7:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
+autoprefixer@10.4.8:
+  version "10.4.8"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.8.tgz#92c7a0199e1cfb2ad5d9427bd585a3d75895b9e5"
+  integrity sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==
+  dependencies:
+    browserslist "^4.21.3"
+    caniuse-lite "^1.0.30001373"
+    fraction.js "^4.2.0"
+    normalize-range "^0.1.2"
+    picocolors "^1.0.0"
+    postcss-value-parser "^4.2.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -223,6 +240,16 @@ browserslist@^4.20.3:
     node-releases "^2.0.3"
     picocolors "^1.0.0"
 
+browserslist@^4.21.3:
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.3.tgz#5df277694eb3c48bc5c4b05af3e8b7e09c5a6d1a"
+  integrity sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==
+  dependencies:
+    caniuse-lite "^1.0.30001370"
+    electron-to-chromium "^1.4.202"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.5"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz"
@@ -251,6 +278,11 @@ caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001335:
   version "1.0.30001342"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz#87152b1e3b950d1fbf0093e23f00b6c8e8f1da96"
   integrity sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==
+
+caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
+  version "1.0.30001384"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001384.tgz#029527c2d781a3cfef13fa63b3a78a6088e35973"
+  integrity sha512-BBWt57kqWbc0GYZXb47wTXpmAgqr5LSibPzNjk/AWMdmJMQhLqOl3c/Kd4OAU/tu4NLfYkMx8Tlq3RVBkOBolQ==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -460,6 +492,11 @@ electron-to-chromium@^1.4.17:
   version "1.4.48"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.48.tgz#1948b5227aa0ca1ed690945eae1adbe9e7904575"
   integrity sha512-RT3SEmpv7XUA+tKXrZGudAWLDpa7f8qmhjcLaM6OD/ERxjQ/zAojT8/Vvo0BSzbArkElFZ1WyZ9FuwAYbkdBNA==
+
+electron-to-chromium@^1.4.202:
+  version "1.4.233"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.233.tgz#aa142e45468bda111b88abc9cc59d573b75d6a60"
+  integrity sha512-ejwIKXTg1wqbmkcRJh9Ur3hFGHFDZDw1POzdsVrB2WZjgRuRMHIQQKNpe64N/qh3ZtH2otEoRoS+s6arAAuAAw==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1145,6 +1182,11 @@ node-releases@^2.0.3:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.4.tgz#f38252370c43854dc48aa431c766c6c398f40476"
   integrity sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==
 
+node-releases@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
+  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
+
 normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz"
@@ -1520,10 +1562,10 @@ sass@1.52.1:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-sass@1.52.2:
-  version "1.52.2"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.2.tgz#cd1f03e0e7be5bb2cebcf1c34d735f087d790936"
-  integrity sha512-mfHB2VSeFS7sZlPv9YohB9GB7yWIgQNTGniQwfQ04EoQN0wsQEv7SwpCwy/x48Af+Z3vDeFXz+iuXM3HK/phZQ==
+sass@1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.54.0.tgz#24873673265e2a4fe3d3a997f714971db2fba1f4"
+  integrity sha512-C4zp79GCXZfK0yoHZg+GxF818/aclhp9F48XBu/+bm9vXEVAYov9iU3FBVRMq3Hx3OA4jfKL+p2K9180mEh0xQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -1861,6 +1903,14 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+update-browserslist-db@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
+  integrity sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -1897,18 +1947,18 @@ vanilla-framework@3.0.1:
     postcss-cli "9.1.0"
     sass "1.45.2"
 
-vanilla-framework@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.5.0.tgz#966024ec79f33450103c6e93fc0cda6337003954"
-  integrity sha512-4Sd67/DDXzv1gG3eiHlwdC9BL1pI7SEorBd/lm3X6Z151di7hoU2YqCJTll+jM2pLf4DpD3cGyEYo3ueuXKoGA==
+vanilla-framework@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.7.0.tgz#0468fb03011d8792ed3f25f4fec36ac5f5af0ea4"
+  integrity sha512-NCwqj17vRkz+tCv4PXvyaOVLZB2/a/+rtlccPlqThNmfn4FPcXVwG3jVokeNWH9rIIus3vr1SBVs/a/B69Ljjg==
   dependencies:
     "@canonical/cookie-policy" "3.4.0"
-    "@canonical/latest-news" "1.3.0"
-    autoprefixer "10.4.7"
+    "@canonical/latest-news" "1.4.1"
+    autoprefixer "10.4.8"
     postcss "8.4.14"
     postcss-cli "9.1.0"
     postcss-scss "4.0.4"
-    sass "1.52.2"
+    sass "1.54.0"
     yaml "1.10.2"
 
 verbalize@^0.1.2:


### PR DESCRIPTION
## Done

Updates side navigation in docs with new expandable functionality.

Demo:
https://juju-is-431.demos.haus/docs/olm
https://juju-is-431.demos.haus/docs/sdk
https://juju-is-431.demos.haus/docs/dev

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit docs and make sure expandable nav works as expected
  - https://juju-is-431.demos.haus/docs/olm
  - https://juju-is-431.demos.haus/docs/sdk
  - https://juju-is-431.demos.haus/docs/dev
  - (note that `>` in the text of navigation items will be removed from content when this version is ready to go live)
- QA the side nav on small screens

## Screenshots

<img width="1299" alt="image" src="https://user-images.githubusercontent.com/83575/187442927-460a15ae-3dad-450c-a159-2a5056284928.png">
