### PR TITLE
Add opengraph meta tags for url, site type and title

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,9 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   <meta name="description" content="{% block page_description %}Juju is an open source application modelling tool that allows you to deploy, configure, scale and operate cloud infrastructures quickly and efficiently on public clouds such as AWS, GCE, and Azure along with private ones such as MAAS, OpenStack, and VSphere.{% endblock %}" />
   <link rel="stylesheet" href="{{ versioned_static('css/styles.css') }}" />
+  <meta property="og:url" content="https://juju.is/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Take control of Kubernetes">
   <title>
     Juju | {% block title %}The simplest way to deploy and maintain
     applications in the cloud{% endblock %}


### PR DESCRIPTION
## Done

- Add opengraph meta tags for url, type and title

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #422

## Screenshots

[if relevant, include a screenshot]
