### PR TITLE
Fix title block bug

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}About - Charmed Operator Framework for Kubernetes and VMs{% endblock title %}
-{% block meta_title %}About - Charmed Operator Framework for Kubernetes and VMs{% endblock title %}
+{% block title %}About - Charmed Operator Framework for Kubernetes and VMs{% endblock %}
+{% block meta_title %}About - Charmed Operator Framework for Kubernetes and VMs{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/186zQ7bYE-jXqNNTyKEvSzjq-yP-MiMW2zHKbgyrBrm4/edit#{% endblock meta_copydoc %}
 

--- a/templates/model-driven-operations-manifesto.html
+++ b/templates/model-driven-operations-manifesto.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}The Open Operator Manifesto{% endblock title %}
-{% block meta_title %}The Open Operator Manifesto{% endblock title %}
+{% block title %}The Open Operator Manifesto{% endblock %}
+{% block meta_title %}The Open Operator Manifesto{% endblock %}
 
 {% block meta_description %}We lead the Open Operator Collection, on a mission to elevate the art of dev&ndash;sec&ndash;ops with open&ndash;source operators that control enterprise applications{% endblock %}
 


### PR DESCRIPTION
## Done

Fixed a bug with duplicate title closing blocks in the templates

## QA
- Go to https://juju-is-447.demos.haus/about
- View source and check that the og:title meta tag matches `<meta property="og:title" content="About - Charmed Operator Framework for Kubernetes and VMs">`