### PR TITLE
Remove JAAS from navigation

### DIFF
--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -107,9 +107,6 @@
             </li>
           </ul>
         </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://jaas.ai">JAAS</a>
-        </li>
       </ul>
       <ul class="p-navigation__items global-nav"></ul>
     </nav>


### PR DESCRIPTION
## Done

Removed JAAS from navigation

## QA
- Go to https://juju-is-453.demos.haus/
- Check that JAAS is not in the navigation

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2403