### PR TITLE
Feature strip title stick to the top

### DIFF
--- a/static/sass/_patterns_what-is-juju.scss
+++ b/static/sass/_patterns_what-is-juju.scss
@@ -39,7 +39,7 @@
         margin-bottom: -6rem;
         padding: 1rem 0 0.5rem;
         position: sticky;
-        top: 56px;
+        top: 0;
         z-index: 5;
       }
 


### PR DESCRIPTION
## Done

Feature strip title stick to the top

## QA

- Go to the homepage and scroll down
- When you get to the "What is Juju?" section
- The title sticks to the top now the header is not sticky