### PR TITLE
Update redirects.yaml for tutorial redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -13,6 +13,8 @@ ops-code-quality/?: /about
 overview/?: /about
 universal-operators/?: /about
 docs/(lma2|cos)(?P<page>.*)/?: https://charmhub.io/topics/canonical-observability-stack{page}
+
+# Redirect tutorials
 tutorials/deploy-nextcloud-and-collabora-on-ubuntu/?: https://charmhub.io/nextcloud/
 tutorials/build-and-deploy-mini-charm/?: /docs/sdk/build-and-deploy-minimal-machine-charm
 tutorials/monitor-elasticsearch-with-elasticsearch-and-kibana/?: /docs/olm/monitor-elasticsearch-with-elasticsearch-and-kibana
@@ -24,4 +26,4 @@ tutorials/publish-on-charmhub/?: /docs/sdk/publishing
 tutorials/how-to-work-with-resources-in-charmcraft/?: /docs/sdk/resources
 tutorials/how-to-work-with-bundles-in-charmcraft/?: /docs/sdk/manage-bundles
 tutorials/deploy-postgres-on-ubuntu-server/?: /docs/olm/how-to
-tutorials/?: /docs/tutorials
+tutorials(.*?): /docs/sdk/tutorials

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -13,3 +13,15 @@ ops-code-quality/?: /about
 overview/?: /about
 universal-operators/?: /about
 docs/(lma2|cos)(?P<page>.*)/?: https://charmhub.io/topics/canonical-observability-stack{page}
+tutorials/deploy-nextcloud-and-collabora-on-ubuntu/?: https://charmhub.io/nextcloud/
+tutorials/build-and-deploy-mini-charm/?: /docs/sdk/build-and-deploy-minimal-machine-charm
+tutorials/monitor-elasticsearch-with-elasticsearch-and-kibana/?: /docs/olm/monitor-elasticsearch-with-elasticsearch-and-kibana
+tutorials/streaming-hadoop-analysis/?: /docs/olm/how-to
+tutorials/build-a-minimal-operator/?: /docs/sdk/from-zero-to-hero-write-your-first-kubernetes-charm
+tutorials/document-your-library/?: /docs/sdk/document-your-charm-library
+tutorials/get-started-hadoop-spark/?: /docs/olm/how-to
+tutorials/publish-on-charmhub/?: /docs/sdk/publishing
+tutorials/how-to-work-with-resources-in-charmcraft/?: /docs/sdk/resources
+tutorials/how-to-work-with-bundles-in-charmcraft/?: /docs/sdk/manage-bundles
+tutorials/deploy-postgres-on-ubuntu-server/?: /docs/olm/how-to
+tutorials/?: /docs/tutorials

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -15,6 +15,7 @@ universal-operators/?: /about
 docs/(lma2|cos)(?P<page>.*)/?: https://charmhub.io/topics/canonical-observability-stack{page}
 
 # Redirect tutorials
+tutorials/charmed-osm-get-started/?: https://charmhub.io/osm/docs/tutorial
 tutorials/deploy-nextcloud-and-collabora-on-ubuntu/?: https://charmhub.io/nextcloud/
 tutorials/build-and-deploy-mini-charm/?: /docs/sdk/build-and-deploy-minimal-machine-charm
 tutorials/monitor-elasticsearch-with-elasticsearch-and-kibana/?: /docs/olm/monitor-elasticsearch-with-elasticsearch-and-kibana


### PR DESCRIPTION
## Done

- Redirect all tutorials to appropriate docs or charms.

## QA

Visit the demo and try to visit each url in this PR:
- https://juju-is-462.demos.haus/tutorials/charmed-osm-get-started
- https://juju-is-462.demos.haus/tutorials/deploy-nextcloud-and-collabora-on-ubuntu
- https://juju-is-462.demos.haus/tutorials/build-and-deploy-mini-charm
- https://juju-is-462.demos.haus/tutorials/monitor-elasticsearch-with-elasticsearch-and-kibana
- https://juju-is-462.demos.haus/tutorials/streaming-hadoop-analysis
- https://juju-is-462.demos.haus/tutorials/build-a-minimal-operator
- https://juju-is-462.demos.haus/tutorials/document-your-library
- https://juju-is-462.demos.haus/tutorials/get-started-hadoop-spark
- https://juju-is-462.demos.haus/tutorials/publish-on-charmhub
- https://juju-is-462.demos.haus/tutorials/how-to-work-with-resources-in-charmcraft
- https://juju-is-462.demos.haus/tutorials/how-to-work-with-bundles-in-charmcraft
- https://juju-is-462.demos.haus/tutorials/deploy-postgres-on-ubuntu-server
- https://juju-is-462.demos.haus/tutorials

They should all redirect to an appropriate place.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2431
