### PR TITLE
Update incorrect kubecon date

### DIFF
--- a/templates/operator-day/kubecon-na-2022.html
+++ b/templates/operator-day/kubecon-na-2022.html
@@ -10,7 +10,7 @@
   <section class="p-strip--blue is-dark is-shallow">
     <div class="u-fixed-width">
       <h1>Operator Day 5th edition</h1>
-      <h3>KubeCon NA 2022 - Nov 16th</h3>
+      <h3>KubeCon NA 2022 - Nov 17th</h3>
     </div>
   </section>
 

--- a/templates/operator-day/kubecon-na-2022.html
+++ b/templates/operator-day/kubecon-na-2022.html
@@ -19,7 +19,7 @@
       <p>The 5th Operator Day took place at KubeCon North America 2022. This edition centred on cases where software operators have been applied successfully. The presenters discussed building software operators using Juju, an open-source operator lifecycle manager. Operators implemented for Juju are called Charmed Operators.</p>
 
       <h2>Agenda</h2>
-      <h3>May 16th</h3>
+      <h3>Nov 17th</h3>
       <table>
         <tbody>
           <tr>


### PR DESCRIPTION
## Done

- Fix incorrect date

## QA

- Visit demo: https://juju-is-465.demos.haus/operator-day/kubecon-na-2022
- First date should be Nov 17th

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3175
