### PR TITLE
Fix docs caching by rolling back discourse module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.yaml-responses==1.2.0
-canonicalwebteam.discourse==5.4.1
+canonicalwebteam.discourse==5.2.4
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
Version 5.2.4 precedes https://github.com/canonical/canonicalwebteam.discourse/pull/156 where the infinite caching of the index page was introduced.

## QA

- Go to https://juju-is-471.demos.haus/docs in the demo, and https://juju.is/docs
- Make a change to the index page contents
- See that the change is not reflected on https://juju.is/docs
- See that the change is reflected on the https://juju-is-471.demos.haus/docs

