### PR TITLE
Use latest canonicalwebteam.discourse with caching fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.yaml-responses==1.2.0
-canonicalwebteam.discourse==5.2.4
+canonicalwebteam.discourse==5.4.2
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
Use [the new version of the discourse module](https://github.com/canonical/canonicalwebteam.discourse/pull/164), which includes the discourse caching fix.

## QA

Load https://juju-is-472.demos.haus/docs. Try changing to index page a couple of times (e.g. change `...` to `:` in column headings, and change it back). Reload the `/docs` page and check the changes are reflected each time.