### PR TITLE
docs/olm -> docs/juju

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -29,9 +29,9 @@
     <div class="col-4 p-card" style="display:flex; flex-direction: column; justify-content: space-between;">
       <div>
         <h3 class="p-heading--4"><strong>Juju</strong>, a tool for managing charms.</h4>
-        <p>Juju consists of the command line tool <a href="https://juju.is/docs/olm/the-juju-client">Juju ('juju')</a>.</p>
+        <p>Juju consists of the command line tool <a href="https://juju.is/docs/juju/the-juju-client">Juju ('juju')</a>.</p>
       </div>
-      <p class="u-sv3">Visit <a href="https://juju.is/docs/olm">the Juju docs</a> to start managing charms!</p>
+      <p class="u-sv3">Visit <a href="https://juju.is/docs/juju">the Juju docs</a> to start managing charms!</p>
     </div>
 
     <div class="col-4 p-card" style="display:flex; flex-direction: column; justify-content: space-between;">

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -15,7 +15,7 @@
         </li>
 
         <li class="p-list__item">
-          <a class="p-link--soft" href="/docs/olm/quick-reference"><small>What are Charms?</small></a>
+          <a class="p-link--soft" href="/docs/juju/reference"><small>What are Charms?</small></a>
         </li>
 
         <li class="p-list__item">

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
         <p>A <a href="/docs/sdk/charmed-operators">charm</a> is an operator - business logic encapsulated in reusable software packages that automate every aspect of an application's life.</p>
         <div class="row">
           <div class="col-2">
-            <p><b>Manage</b> charms with <a href="/docs/olm">Juju</a></p>
+            <p><b>Manage</b> charms with <a href="/docs/juju">Juju</a></p>
           </div>
           <div class="col-2">
             <p><b>Try</b> a ready-made charm from <a href="https://charmhub.io">Charmhub</a></p>
@@ -25,7 +25,7 @@
           </div>
         </div>
        <div class="p-button-grid">
-         <a href="/docs/olm/installing-juju" class="p-button--positive u-full-width">Install Juju</a>
+         <a href="/docs/juju/get-started-with-juju" class="p-button--positive u-full-width">Install Juju</a>
        </div>
       </div>
       <div class="col-6 u-align--center u-vertically-center">

--- a/templates/operator-day/index.html
+++ b/templates/operator-day/index.html
@@ -117,7 +117,7 @@
     <p>Read our introduction to <a href="https://juju.is/">Juju and Charms</a></p>
     <ul>
       <li>Browse our collection of charms on <a href="https://charmhub.io/">Charmhub.io</a></li>
-      <li>Learn about <a href="https://juju.is/docs/olm">Juju</a></li>
+      <li>Learn about <a href="https://juju.is/docs/juju">Juju</a></li>
       <li>Learn about the <a href="https://juju.is/docs/sdk">Charm SDK</a></li>
       <li>Watch <a href="https://ubuntu.com/blog/juju-and-charmed-operators-videos">videos  to get started with Juju and charms</a></li>
       <li>Watch the <a href="https://ubuntu.com/engage/developer-guide-to-operators">webinar about charms ready for publication</a></li>

--- a/templates/partials/_juju-supports.html
+++ b/templates/partials/_juju-supports.html
@@ -22,7 +22,7 @@
           <a href="https://juju.is/docs/oci-cloud">Oracle</a>
         </li>
         <li class="p-list__item">
-          <a href="https://juju.is/docs/olm/equinix-metal">Equnix Metal</a>
+          <a href="https://juju.is/docs/juju/equinix-metal">Equnix Metal</a>
         </li>
       </ul>
     </div>

--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -33,7 +33,7 @@
               </a>
               <ul class="p-navigation__sub-list u-no-margin--left u-no-padding--left">
                 <li>
-                  <a class="p-navigation__dropdown-item" href="/docs/olm">Juju docs: Manage charms</a>
+                  <a class="p-navigation__dropdown-item" href="/docs/juju">Juju docs: Manage charms</a>
                 </li>
                 <li>
                   <a class="p-navigation__dropdown-item" href="/docs/sdk">SDK docs: Build charms</a>

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -37,10 +37,10 @@ def init_docs(app):
                 get_topics_query_id=2,
             ),
             index_topic_id=discourse_index_id,
-            url_prefix="/docs/olm",
+            url_prefix="/docs/juju",
         ),
         document_template="docs/document.html",
-        url_prefix="/docs/olm",
+        url_prefix="/docs/juju",
     )
 
     discourse_docs.init_app(app)


### PR DESCRIPTION
## Done

Updated references to /docs/olm -> /docs/juju

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Ensure header link to juju docs links to /docs/juju and everything works as expected


## Issue / Card
Fixes #477 
