### PR TITLE
Redirect all docs/olm/? links to docs/juju/?

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -13,6 +13,8 @@ ops-code-quality/?: /about
 overview/?: /about
 universal-operators/?: /about
 docs/(lma2|cos)(?P<page>.*)/?: https://charmhub.io/topics/canonical-observability-stack{page}
+# Redirect olm docs
+docs/olm/(?P<page>.*?): /docs/juju/{page}
 
 # Redirect tutorials
 tutorials/charmed-osm-get-started/?: https://charmhub.io/osm/docs/tutorial


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit https://juju-is-479.demos.haus/docs/olm/cross-model-integration
- You should get redirected to https://juju-is-479.demos.haus/docs/juju/cross-model-integration

