### PR TITLE
Add root redirect for /docs/olm -> /docs/juju

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -14,6 +14,7 @@ overview/?: /about
 universal-operators/?: /about
 docs/(lma2|cos)(?P<page>.*)/?: https://charmhub.io/topics/canonical-observability-stack{page}
 # Redirect olm docs
+docs/olm/?: /docs/juju
 docs/olm/(?P<page>.*?): /docs/juju/{page}
 
 # Redirect tutorials


### PR DESCRIPTION
## Done

- Added redirect for root /docs/olm -> /docs/juju

## QA

- Visit the https://juju-is-485.demos.haus/
- Go to https://juju-is-485.demos.haus/docs/olm
- Be redirected to demo/docs/juju


## Issue / Card

Fixes #484 
