### PR TITLE
add endpoint for searching discourse docs and rewriting the topics url

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests==2.29.0
 semver==3.0.0
 cachetools==5.3.0
 flask-cors==3.0.10
+Flask-Caching==2.0.2

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,3 +1,5 @@
+from flask import render_template
+from flask_cors import cross_origin
 import datetime
 import os
 
@@ -12,11 +14,9 @@ from canonicalwebteam.yaml_responses.flask_helpers import (
     prepare_deleted,
     prepare_redirects,
 )
-from flask import render_template
-from flask_cors import cross_origin
 
 from webapp.blog.views import init_blog
-from webapp.docs.views import init_docs
+from webapp.docs.views import init_docs, search_docs, cache
 from webapp.greenhouse import Greenhouse
 from webapp.template_utils import current_url_with_query, static_url
 
@@ -33,6 +33,8 @@ app = FlaskBase(
     favicon_url="https://assets.ubuntu.com/v1/5d4edefd-jaas-favicon.png",
 )
 
+cache.init_app(app)
+app.register_blueprint(search_docs)
 app.before_request(prepare_redirects())
 app.before_request(prepare_deleted())
 

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -1,12 +1,204 @@
 from os import getenv
-
+from bs4 import BeautifulSoup
+from flask import Blueprint, request, make_response
 import talisker.requests
+import requests
+from urllib.parse import quote
+from flask_caching import Cache
 
 from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
 from canonicalwebteam.search import build_search_view
 
 DISCOURSE_API_KEY = getenv("DISCOURSE_API_KEY")
 DISCOURSE_API_USERNAME = getenv("DISCOURSE_API_USERNAME")
+
+search_docs = Blueprint("search_docs", __name__)
+
+cache = Cache(config={"CACHE_TYPE": "simple"})
+docs_id_cache = {
+    "olm": {"id": 1087, "tag": "juju"},
+    "sdk": {"id": 4449, "tag": "sdk"},
+    "dev": {"id": 6669, "tag": "dev"},
+}
+
+
+def map_topic_to_doc(topic):
+    for key in docs_id_cache.keys():
+        if key in topic["tags"]:
+            return docs_id_cache[key]["id"]
+
+
+def rewrite_topic_url(topics: list, posts: list):
+    topics_with_url_ids = []
+    for topic in topics:
+        index_id = map_topic_to_doc(topic)
+        index_details = cache.get(index_id)
+        if index_details:
+            nav_table = BeautifulSoup(
+                index_details["nav_table"], "html.parser"
+            )
+        else:
+            index_page = requests.get(
+                f"https://discourse.charmhub.io/t/{index_id}.json"
+            ).json()
+            index_doc = (
+                index_page.get("post_stream").get("posts")[0].get("cooked")
+            )
+            soup = BeautifulSoup(index_doc, "html.parser")
+            nav_heading = soup.find("h2", text="Navigation")
+            nav_table = nav_heading.find_next_sibling("details").find("table")
+            cache.set(index_id, {"nav_table": str(nav_table)}, timeout=3600)
+        topic_link = nav_table.find(
+            "a", href=lambda href: href and str(topic["id"]) in href
+        )
+        if topic_link:
+            topic_row_in_nav = topic_link.find_parent("tr")
+            topic_data = topic_row_in_nav.find_all("td")
+            topic_path = topic_data[1].text
+            topic_urls = []
+            for tag in topic["tags"]:
+                if tag in docs_id_cache.keys():
+                    url_tag = docs_id_cache[tag]["tag"]
+                    topic_url = f"https://juju.is/docs/{url_tag}/{topic_path}"
+                    topic_urls.append(topic_url)
+                topic["url"] = topic_urls
+            topics_with_url_ids.append(topic["id"])
+    topics_with_url = [
+        topic for topic in topics if topic["id"] in topics_with_url_ids
+    ]
+    posts_with_topic_url = [
+        post for post in posts if post["topic_id"] in topics_with_url_ids
+    ]
+    return {"posts": posts_with_topic_url, "topics": topics_with_url}
+
+
+def get_docs(term: str, page: int, see_all=False):
+    """
+    Fetches documentation from discourse based on category and
+    a specific search term.
+
+    Parameters:
+        search_term (str): The search term used to find relevant documentation.
+        page (int): The page number of the search results to retrieve.
+        see_all (bool, optional): If True, retrieves all available search
+        results. If False (default), returns a limited number of results
+        (4 posts and topics).
+
+    Returns:
+        dict: A dictionary containing the retrieved documentation.
+            - If there are no results found, the dictionary will contain an
+                "error" key with the value "No results found".
+            - If `see_all` is True, the dictionary will contain all the
+                available posts and topics.
+            - If `see_all` is False the dictionary will contain only 4 posts
+                and topics.
+
+    Note:
+        This function makes use of a cache to store result for a fetched search
+        terms, it clears cache when another term is searched and this helps in
+        reducing redundant requests to the charmhub.io discourse API.
+    """
+    categories = ["#doc"]
+    encoded_cat = [quote(cat) for cat in categories]
+    tags = ["olm", "sdk", "dev"]
+    query = f"{term} {' '.join(encoded_cat)} tag:{','.join(tags)}".strip()
+
+    search_url = f"https://discourse.charmhub.io/search.json?q={query}"
+
+    resp = {}
+    cached_page = cache.get(f"{term}_{page}")
+    if not cached_page:
+        docs = requests.get(f"{search_url}&page={page}").json()
+
+        if not docs.get("topics"):
+            return {"error": "No results found"}
+
+        # filter out archived topics
+        topics = [
+            topic for topic in docs.get("topics") if not topic["archived"]
+        ]
+        posts = docs.get("posts")
+
+        resp = rewrite_topic_url(topics, posts)
+        cache.set(f"{term}_{page}", resp, timeout=600)  # 10 min cache
+    else:
+        resp = cached_page
+    if page == 1 and not see_all:
+        response = {
+            "topics": resp["topics"][:4],
+            "posts": resp["posts"][:4],
+        }
+        return response
+
+    return resp
+
+
+def get_all(doc_type: str, search_term: str, page: int):
+    """
+    Returns paginated documentation of a specific type(post or topic) from the
+    charmhub.io discourse.
+
+    Parameters:
+        doc_type (str): type of documentation to fetch ("posts" or "topics").
+        search_term (str): The search term used to find relevant documentation.
+        page (int): The page number of the search results to retrieve.
+
+    Returns:
+        dict: A dictionary containing the paginated documentation of the
+        specified type.
+            - If there are no results found for the provided `search_term`,
+                the dictionary will contain an "error" key
+                with the value "No results found", and a 404 status code will
+                be returned.
+            - If there are results, the dictionary will contain the paginated
+                requested `doc_type` (e.g., "posts" or "topics") and the total
+                pages
+    """
+    see_all = True
+    count = 10
+    page = page
+
+    doc_page = -((count * page) // -50)
+    docs = get_docs(search_term, page=doc_page, see_all=see_all)
+    if "error" not in docs:
+        all = docs.get(doc_type, [])
+        end = page * count
+        start = end - count
+        if start >= len(all):
+            end = len(all)
+            start = end - count
+        # find a way of calculating total pages
+        posts_per_page = {
+            doc_type: all[start:end],
+        }
+
+        return make_response(posts_per_page, 200)
+    else:
+        return make_response({"error": "No results found"}, 404)
+
+
+@search_docs.route("/docs/search.json")
+def search_discourse_docs():
+    search_term = request.args.get("q")
+    page = int(request.args.get("page", 1))
+    docs = get_docs(search_term, page)
+    return docs
+
+
+@search_docs.route("/docs/search/all_posts.json")
+def search_discourse_docs_all_posts():
+    search_term = request.args.get("q")
+    page = int(request.args.get("page", 1))
+
+    return get_all("posts", search_term, page)
+
+
+@search_docs.route("/docs/search/all_topics.json")
+def search_discourse_docs_all_topics():
+    search_term = request.args.get("q")
+    page = int(request.args.get("page", 1))
+
+    return get_all("topics", search_term, page)
 
 
 def init_docs(app):


### PR DESCRIPTION
## Done
- `/docs/search.json` `/docs/search/all_posts.json` `/docs/search/all_topics.json`
- create endpoints for searching discourse docs
- add topics url to each topic in the result by rewriting the discourse url

## QA
- Go to https://juju-is-486.demos.haus/docs/search.json?q={search-term}&page={page}
    - if page is 1, Check that the endpoint only returns 4 topics and posts
    - otherwise the full list of posts and topics should be returned
- Go to https://juju-is-486.demos.haus/docs/search/all_posts?q={search-term}&page={page} and ensure that a paginated list of post is returned
- Go to https://juju-is-486.demos.haus/docs/search/all_topics?q={search-term}&page={page} and ensure that a paginated list of topic is returned
- Check that every topic has a list of urls and each url must match the list of tags for tags that are any of olm, sdk or dev



## Issue / Card https://warthogs.atlassian.net/browse/WD-5270

