### PR TITLE
Remove text-width limit for docs

### DIFF
--- a/static/sass/_patterns_docs.scss
+++ b/static/sass/_patterns_docs.scss
@@ -5,6 +5,10 @@
 @mixin juju-docs {
   $sidebar-width: 18rem;
 
+  .docs #main-content p {
+    max-width: none;
+  }
+
   .l-docs {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Done

- Override default `max-width: 40em` for paragraphs on docs pages.

## QA

- Visit the https://juju-is-487.demos.haus/docs/juju/manual#heading--limitations
- See that all elements are the same widfth.


## Issue / Card

Fixes #369
