### PR TITLE
Bump canonicalwebteam.discourse to 5.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.yaml-responses==1.2.0
-canonicalwebteam.discourse==5.4.2
+canonicalwebteam.discourse==5.4.3
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.4.3

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Browse the discourse powered sections in the demo environment and check they work.
