### PR TITLE
fix: update mattermost links to matrix

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -458,7 +458,7 @@
     <div class="row">
       <div class="col-9 col-start-large-4">
         <div class="u-fixed-width"><hr class="p-rule"></div>
-        <p>Learn more about charms on <a href="http://discourse.charmhub.io">Discourse</a> and <a href="http://chat.charmhub.io">Mattermost</a></p>
+        <p>Learn more about charms on <a href="http://discourse.charmhub.io">Discourse</a> and <a href="https://matrix.to/#/#charmhub:ubuntu.com">Matrix</a></p>
       </div>
     </div>
   </section>

--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -28,7 +28,7 @@
               <a href="https://discourse.charmhub.io/" class="p-navigation__dropdown-item">Discourse forum</a>
             </li>
             <li>
-              <a href="https://chat.charmhub.io" class="p-navigation__dropdown-item">Mattermost chat</a>
+              <a href="https://matrix.to/#/#charmhub:ubuntu.com" class="p-navigation__dropdown-item">Matrix chat</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
## Done

- Update navigation from a Mattermost link to Matrix
- Update homepage link from Mattermost to Matrix

## QA
- Visit the demo
- Check the "Community" navigation dropdown has a link to matrix.
- Check the homepage, search "matrix"

## Issue / Card

Fixes #739

