### PR TITLE
Update the dashboard gif

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -504,9 +504,9 @@
       <div class="col-6 col-start-large-4">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/619c0cec-juju.gif",
+            url="https://assets.ubuntu.com/v1/ed078d85-juju-dashboard.gif",
             alt="",
-            height="682",
+            height="779",
             width="1200",
             hi_def=True,
             loading="lazy",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -60,7 +60,7 @@ def get_latest_versions():
     try:
         result = {}
 
-        # get dashboard verion
+        # get dashboard version
         dashboard_response = requests.get(
             "/".join(
                 [


### PR DESCRIPTION
## Done

- Update the dashboard gif for the 0.12.0 release.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to the homepage and scroll down until you get to the dashboard gif.
- Check that the images use the new, grey theme.
