### PR TITLE
Fix navigation bar wrapping on smaller screen sizes

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -6,6 +6,7 @@
 $color-accent-background: #f0f5f7;
 $color-accent: #e95420;
 $breakpoint-medium: 619px;
+$breakpoint-large: 1220px;
 
 @import "vanilla-framework/scss/vanilla";
 


### PR DESCRIPTION
## Done

Adds the `$breakpoint-large` value to avoid the nav bar wrapping onto a new line on smaller screens. The nav bar now switches to mobile version at this new breakpoint instead.

## QA

- Go to the demo
- Check the nav bar switches to mobile version rather than wrapping onto two lines on smaller screens

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10734

## Screenshots

Before:
![Screenshot from 2024-05-03 17-19-23](https://github.com/canonical/juju.is/assets/74302970/07410c64-360a-438a-a844-92638c5d20cd)

After:
![Screenshot from 2024-05-03 17-21-40](https://github.com/canonical/juju.is/assets/74302970/b9d68fd0-c992-476c-a2de-89bc858f794e)

