### PR TITLE
Build p-tabs--25-75 for Juju middle pages

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -313,7 +313,7 @@ html {
   .p-tabs__list {
     @extend %vf-pseudo-border--bottom;
     margin-bottom: 0;
-    padding-left: 0.5rem;
+    margin-left: -1rem;
 
     &::after {
       content: none;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -299,7 +299,7 @@ html {
   position: relative;
   margin-bottom: 1.5rem;
 
-  .full-width-border {
+  &::before {
     content: '';
     position: absolute;
     left: 0;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -296,7 +296,10 @@ html {
 
   .p-tabs__list {
     margin-bottom: 0;
-    margin-left: -$sph--large;
+
+    @media screen and (min-width: $breakpoint-large) {
+      margin-left: -$sph--large;
+    }
 
     // hiding the bottom border from p-tabs__list as it is moved to p-tabs
     &::after {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -297,7 +297,7 @@ html {
 .p-tabs--25-75 {
   @extend %vf-row;
   position: relative;
-  margin-bottom: 1.5rem;
+  margin: 0 auto $spv--x-large;
 
   &::before {
     content: '';

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -296,25 +296,15 @@ html {
 
 .p-tabs--25-75 {
   @extend %vf-row;
+  @extend %vf-pseudo-border--bottom;
   position: relative;
   margin: 0 auto $spv--x-large;
 
-  &::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 1px;
-    width: 100%;
-    background-color: $colors--theme--border-default;
-  }
-
   .p-tabs__list {
-    @extend %vf-pseudo-border--bottom;
     margin-bottom: 0;
-    margin-left: -1rem;
+    margin-left: -$sph--large;
 
+    // hiding the bottom border from p-tabs__list as it is moved to p-tabs
     &::after {
       content: none;
     }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -299,16 +299,13 @@ html {
 
     @media screen and (min-width: $breakpoint-large) {
       margin-left: -$sph--large;
+      grid-column-start: 4;
+      grid-column-end: span 9;
     }
 
     // hiding the bottom border from p-tabs__list as it is moved to p-tabs
     &::after {
       content: none;
-    }
-
-    @media screen and (min-width: $breakpoint-large) {
-      grid-column-start: 4;
-      grid-column-end: span 9;
     }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -294,9 +294,35 @@ html {
   display: inline-block;
 }
 
-.middle-page-tabs {
-  @media screen and (min-width: $breakpoint-large) {
-    padding-left: 20.3rem;
+.p-tabs--25-75 {
+  @extend %vf-row;
+  position: relative;
+  margin-bottom: 1.5rem;
+
+  .full-width-border {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1px;
+    width: 100%;
+    background-color: $colors--theme--border-default;
+  }
+
+  .p-tabs__list {
+    @extend %vf-pseudo-border--bottom;
+    margin-bottom: 0;
+    padding-left: 0.5rem;
+
+    &::after {
+      content: none;
+    }
+
+    @media screen and (min-width: $breakpoint-large) {
+      grid-column-start: 4;
+      grid-column-end: span 9;
+    }
   }
 }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -73,12 +73,6 @@ $breakpoint-large: 1220px;
   }
 }
 
-// TODO: to be removed when fixed in Vanilla
-// https://github.com/canonical/vanilla-framework/issues/4947
-body:not(.docs) .p-navigation__banner {
-  padding-left: 0;
-}
-
 .u-hide--x-large {
   @media only screen and (min-width: $grid-max-width) {
     display: none;

--- a/templates/how-juju-works.html
+++ b/templates/how-juju-works.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="u-fixed-width">
   <nav class="p-tabs--25-75">
-    <ul class="p-tabs__list u-no-margin--top" role="tablist">
+    <ul class="p-tabs__list" role="tablist">
       <li class="p-tabs__item" role="presentation">
         <a href="/why-juju" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "why-juju" %}aria-selected="true"{% endif %}>
           Why Juju?

--- a/templates/how-juju-works.html
+++ b/templates/how-juju-works.html
@@ -2,8 +2,9 @@
 
 {% block content %}
 <div class="u-fixed-width">
-  <nav class="p-tabs">
-    <ul class="p-tabs__list u-no-margin--top middle-page-tabs" role="tablist">
+  <nav class="p-tabs--25-75">
+    <div class="full-width-border"></div>
+    <ul class="p-tabs__list u-no-margin--top" role="tablist">
       <li class="p-tabs__item" role="presentation">
         <a href="/why-juju" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "why-juju" %}aria-selected="true"{% endif %}>
           Why Juju?

--- a/templates/how-juju-works.html
+++ b/templates/how-juju-works.html
@@ -3,7 +3,6 @@
 {% block content %}
 <div class="u-fixed-width">
   <nav class="p-tabs--25-75">
-    <div class="full-width-border"></div>
     <ul class="p-tabs__list u-no-margin--top" role="tablist">
       <li class="p-tabs__item" role="presentation">
         <a href="/why-juju" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "why-juju" %}aria-selected="true"{% endif %}>

--- a/templates/partials/_navigation.html
+++ b/templates/partials/_navigation.html
@@ -78,13 +78,9 @@
     </div>
   </div>
   {% else %}
-  <div class="row">
-    <div class="col-3">
-      {{ nav_logo() }}
-    </div>
-    <div class="col-9">
-      {{ nav_items() }}
-    </div>
+  <div class="p-navigation__row--25-75">
+    {{ nav_logo() }}
+    {{ nav_items() }}
   </div>
   {% endif %}
 </header>


### PR DESCRIPTION
## Done
- Build `p-tabs--25-75` for Juju middle pages

## QA
- Go to https://juju-is-529.demos.haus/why-juju and change screen sizes
- Check if the tabs are aligned with and responsive to the main navigation 

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-10814

## Screenshots
<img width="640" alt="Screenshot 2024-05-06 at 10 39 24 AM" src="https://github.com/canonical/juju.is/assets/90341644/9d1e04c0-1b5b-4b54-bf25-33b99ed2c924">

