### PR TITLE
fix: ensure bold text renders correctly

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -320,3 +320,7 @@ html {
   content: counter(listItem) ". ";
   font-weight: bold;
 }
+
+strong {
+  font-weight: bold !important;
+}


### PR DESCRIPTION
## Done
Add CSS `!important` flag to ensure bold text renders correctly in Juju docs. 
(I initially thought this was an issue with the `canonicalwebteam.discourse` parser, but the HTML was already rendering with `<strong>` tags, so there was an underlying CSS issue).

## QA

- Check [updated docs](https://juju-is-534.demos.haus/docs/juju/manage-models#heading--configure-a-model) against [current docs](https://juju.is/docs/juju/manage-models#heading--configure-a-model)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-11923
