### PR TITLE
chore: Bump canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "stylelint-config-recommended-scss": "14.0.0",
     "stylelint-order": "6.0.4",
     "stylelint-prettier": "5.0.0",
-    "vanilla-framework": "4.13.0",
+    "vanilla-framework": "4.14.0",
     "watch-cli": "0.2.3"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.blog==6.4.2
 canonicalwebteam.yaml-responses==1.2.0
-canonicalwebteam.discourse==5.5.0
+canonicalwebteam.discourse==5.6.0
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,10 +1722,10 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-vanilla-framework@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.13.0.tgz#3901952faf819be42b24d2efc719c73de384a8ab"
-  integrity sha512-mUSJqs56ycxpEZwplTOiy4SfihjWsPiAddnQZ9b0s0ak8mLHVxnJF1aNIpPixPWK/NvhD9jVACn5qa2pGabRMQ==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Bumps canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0

## QA

- Check the changes in vanilla have not broken anything
- Go to docs (e.g. https://juju-is-540.demos.haus/docs/juju) and hover over a h2 heading, see the [vanilla anchor link](https://vanillaframework.io/docs/patterns/links#anchor-link) works as expected
- Inspect the heading and see there are no trailing numbers on the heading 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12933