### PR TITLE
chore: Adds redirect for /docs/olm/install-juju

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -14,6 +14,7 @@ overview/?: /about
 universal-operators/?: /about
 docs/(lma2|cos)(?P<page>.*)/?: https://charmhub.io/topics/canonical-observability-stack{page}
 # Redirect olm docs
+/docs/olm/install-juju: /docs/juju/install-and-manage-the-client
 docs/olm/?: /docs/juju
 docs/olm/(?P<page>.*?): /docs/juju/{page}
 


### PR DESCRIPTION
## Done

Adds redirect from `/docs/olm/install-juju` > `/docs/juju/install-and-manage-the-client` as the global `/docs/olm/*` does not redirect this url
