### PR TITLE
chore: Adds redirect to /docs/juju/install-and-manage-the-client

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -13,8 +13,9 @@ ops-code-quality/?: /about
 overview/?: /about
 universal-operators/?: /about
 docs/(lma2|cos)(?P<page>.*)/?: https://charmhub.io/topics/canonical-observability-stack{page}
+docs/juju/install-juju: /docs/juju/install-and-manage-the-client
 # Redirect olm docs
-/docs/olm/install-juju: /docs/juju/install-and-manage-the-client
+docs/olm/install-juju: /docs/juju/install-and-manage-the-client
 docs/olm/?: /docs/juju
 docs/olm/(?P<page>.*?): /docs/juju/{page}
 


### PR DESCRIPTION
## Done

Adds redirect from `/docs/juju/install-juju` to `/docs/juju/install-and-manage-the-client`