### PR TITLE
chore: Downgrades `@canonical/cookie-policy` to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "3.6.3",
+    "@canonical/cookie-policy": "3.5.0",
     "@canonical/discourse-rad-parser": "1.0.1",
     "@canonical/global-nav": "3.6.4",
     "autoprefixer": "10.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,10 +174,10 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@canonical/cookie-policy@3.6.3":
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.3.tgz#b242dd3cd838564be16e20c6bfadb92f6058950d"
-  integrity sha512-an3od9wrtESgbexSu4Cc81vyHExZaeDeDJWd0+g2SANSAt3OFMt+gsT2c78rGep9J7+a1qhuvQRC43koSVWACQ==
+"@canonical/cookie-policy@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.5.0.tgz#1c7e6cc2d5a7218375001b2cff2996a927693e89"
+  integrity sha512-XLCIl8+h+3BRfvqADqFsmAfWdaDGDchY/TPCKtpeQdb4r64SR6arsdNftlOb7vX8EuLCK2QRp6evUy0J+qnQTg==
 
 "@canonical/discourse-rad-parser@1.0.1":
   version "1.0.1"


### PR DESCRIPTION
## Done

- Downgrades `@canonical/cookie-policy` from 3.6.3 to 3.5.0 as when opting out of cookies, the cookie popup would still appear when navigating to different pages within the `juju.is` domain

## QA

1. clear out all cookies on https://juju-is-544.demos.haus/
2. refresh page, when the popup shows up, click "Manage your tracker settings"
3. make sure performance and functionality are disabled
4. click "Save preferences"
5. go to another page within the same domain (e.g. https://juju-is-544.demos.haus/docs)
6. ensure popup does not show up

^ compare this with current production version and you should see the popup reappearing