### PR TITLE
chore: bump canonicalwebteam.search module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.blog==6.4.2
 canonicalwebteam.yaml-responses==1.2.0
 canonicalwebteam.discourse==5.6.1
-canonicalwebteam.search==1.3.0
+canonicalwebteam.search==2.1.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 black==24.3.0

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -89,6 +89,7 @@ def init_docs(app):
         "/docs/search",
         "docs-search",
         build_search_view(
+            app=app,
             session=session,
             site="juju.is/docs",
             template_path="docs/search.html",


### PR DESCRIPTION
## Done
Bumps `canonicalwebteam.search` module version
- relied on bumping `flask-base` also, and adding a missing argument

## How to QA
Click around and make sure the site works as usual

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no new behaviour

## Issue / Card

Fixes [WD-15008](https://warthogs.atlassian.net/browse/WD-15008)

[WD-15008]: https://warthogs.atlassian.net/browse/WD-15008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ