### PR TITLE
fix: update improve this page link

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -129,7 +129,11 @@
       <div class="p-notification__content">
         <p class="p-notification__message">
           Last updated {{ document.updated }}. 
-          <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
+          <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>
+          or
+          <a href="https://github.com/canonical/juju.is/issues/new?title=Documentation: {{ document.title }}&body=Docs page: {{ request.url }}%0A%0ADocs source: {{ forum_url }}{{ document.topic_path }}%0A%0AIssue: Please write your issue here.&labels=documentation">
+            File an issue
+          </a>.                   
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done
- Adds a link to the bottom of docs pages to create a new issue on Github

## QA
- Go to any docs page (e.g. https://juju-is-556.demos.haus/docs/juju/manage-relations or other)
- Check the "Help improve this document in the forum" link at the bottom of the page takes the user to the Discourse page for the doc
- Check the "File an issue" link takes the user to a new issue request on Github
- The fields should be as follows:
Title: `Documentation: {Title of doc page}`
Body:
```
Docs page: {link to the docs page on juju.is}

Docs source: {the source page of the documentation on Discourse}

Issue: Please write your issue here.
```
Label on issue: `documentation`

## Issue / Card

Fixes [WD-15315](https://warthogs.atlassian.net/browse/WD-15315)

[WD-15315]: https://warthogs.atlassian.net/browse/WD-15315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ