### PR TITLE
fix: open issue in /juju/docs repo instead of /canonical/juju.is

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -131,7 +131,7 @@
           Last updated {{ document.updated }}. 
           <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>
           or
-          <a href="https://github.com/canonical/juju.is/issues/new?title=Documentation: {{ document.title }}&body=Docs page: {{ request.url }}%0A%0ADocs source: {{ forum_url }}{{ document.topic_path }}%0A%0AIssue: Please write your issue here.&labels=documentation">
+          <a href="https://github.com/juju/docs/issues/new?title=Documentation: {{ document.title }}&body=Docs page: {{ request.url }}%0A%0ADocs source: {{ forum_url }}{{ document.topic_path }}%0A%0AIssue: Please write your issue here.">
             File an issue
           </a>.                   
         </p>


### PR DESCRIPTION
## Done
- For the "File an issue" link, changes the repo to be https://github.com/juju/docs/issues instead of https://github.com/canonical/juju.is/issues/

## QA
Make sure the "File an issue" link at the bottom of a docs page opens a new issue in `/juju/docs` repo