### PR TITLE
Include h3 to docs table of contents

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -110,7 +110,14 @@
         <nav class="p-table-of-contents__nav" aria-label="Table of contents">
           <ul class="p-table-of-contents__list">
             {% for heading in document.headings_map %}
-            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
+              <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
+              {% if heading.children %}
+                <ul class="p-table-of-contents__list">
+                {% for child in heading.children %}
+                  <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ child.heading_slug }}">{{ child.heading_text }}</a></li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
             {% endfor %}
           </ul>
         </nav>


### PR DESCRIPTION
## Done

- Include h3 headings to table of contents (displayed on the right side of the page). H3 contents should nest their parent H2 headings.

## QA

- Go to https://juju-is-564.demos.haus/docs/juju/manage-clouds
- Check that the table of contents on the right side of the page load as expected
- It should catch h2 and h3 headings. H3 headings should nest their corresponding H2 parent headings.

## Issue / Card

Fixes [WD-12952](https://warthogs.atlassian.net/browse/WD-12952) and https://github.com/canonical/canonicalwebteam.discourse/issues/187

## Screenshots

[if relevant, include a screenshot]


[WD-12952]: https://warthogs.atlassian.net/browse/WD-12952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ