### PR TITLE
fix typo on docs page

### DIFF
--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -475,12 +475,12 @@
       <div class="col">
         <div class="p-image-container--square-on-medium p-image-container--square-on-small from-scratch-container">
           <a href="https://ops.readthedocs.io">
-            <img src="https://assets.ubuntu.com/v1/574de944-Any%20Application.svg" alt="build charms with charmcaft and ops" width="800">
+            <img src="https://assets.ubuntu.com/v1/574de944-Any%20Application.svg" alt="build charms with charmcraft and ops" width="800">
           </a>
         </div>
       </div>
       <div class="col">
-        <p>with Charmcaft and Ops</p>
+        <p>with Charmcraft and Ops</p>
         <div class="u-fixed-width">
           <hr class="is-muted">
         </div>


### PR DESCRIPTION
## Done

Fixes typo on `/docs` page

## QA

- Go to https://juju-is-570.demos.haus/docs
- Check the Charmcraft and Ops section at the bottom
- Make sure Charmcraft is spelt right

