### PR TITLE
add missing clouds

### DIFF
--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -155,22 +155,27 @@
                 href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-google-gke-cloud-and-juju">Google
                 GKE</a>&nbsp;&nbsp;&nbsp;
               <a
-                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju">LXD</a>
+                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju">LXD</a>&nbsp;&nbsp;&nbsp;
+              <a
+                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju">MAAS</a>&nbsp;&nbsp;&nbsp;
             </p>
             <p class="p-text--small">
               <a
-                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju">MAAS</a>&nbsp;&nbsp;&nbsp;
+                href="https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/cloud/list-of-supported-clouds/the-manual-cloud-and-juju/#cloud-manual">Manual</a>&nbsp;&nbsp;&nbsp;
+               <a
+                href="https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-microsoft-aks-cloud-and-juju/#cloud-kubernetes-aks">Microsoft
                 AKS</a>&nbsp;&nbsp;&nbsp;
-              <a
-                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju">Microsoft
-                Azure</a>
-
             </p>
             <p class="p-text--small">
               <a
+                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju">Microsoft
+                Azure</a>&nbsp;&nbsp;&nbsp;
+              <a
                 href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>&nbsp;&nbsp;&nbsp;
+            </p>
+            <p class="p-text--small">
               <a
                 href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju">Oracle OCI</a>&nbsp;&nbsp;&nbsp;
               <a

--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -161,9 +161,9 @@
             </p>
             <p class="p-text--small">
               <a
-                href="https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/cloud/list-of-supported-clouds/the-manual-cloud-and-juju/#cloud-manual">Manual</a>&nbsp;&nbsp;&nbsp;
+                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-manual-cloud-and-juju/#cloud-manual">Manual</a>&nbsp;&nbsp;&nbsp;
                <a
-                href="https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>&nbsp;&nbsp;&nbsp;
+                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-microsoft-aks-cloud-and-juju/#cloud-kubernetes-aks">Microsoft
                 AKS</a>&nbsp;&nbsp;&nbsp;
@@ -179,7 +179,7 @@
               <a
                 href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju">Oracle OCI</a>&nbsp;&nbsp;&nbsp;
               <a
-                href="https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/">VMware vSphere</a>
+                href="https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/">VMware vSphere</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done
Adds missing `Manual` and `MicroK8s` clouds from [this list](https://canonical-juju.readthedocs-hosted.com/en/3.6/user/reference/cloud/list-of-supported-clouds/)

## QA
- Go to https://juju-is-571.demos.haus/docs and check the `Connect a Cloud` section
- Make sure all clouds in the above list are present
