### PR TITLE
Mandatory job title fields on juju.is contact form

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -854,19 +854,19 @@
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal" data-js="close-modal-control">Close</button>
     </header>
     <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_5332" style="max-width: 560px;">
-      <label for="firstName">First name</label>
+      <label class="is-required" for="firstName">First name</label>
       <input type="text" name="firstName" id="firstName" required>
   
-      <label for="lastName">Last name</label>
+      <label class="is-required" for="lastName">Last name</label>
       <input type="text" name="lastName" id="lastName" required>
   
       <label class="is-required" for="title">Job title</label>
       <input type="text" name="title" id="title" required>
   
-      <label for="Email">Email address:</label>
+      <label class="is-required" for="Email">Email address:</label>
       <input type="email" name="email" id="email" required>
   
-      <label for="phone">Phone</label>
+      <label class="is-required" for="phone">Phone</label>
       <input type="text" name="phone" id="phone" required>
 
       {% include "partials/_country-field.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -860,7 +860,7 @@
       <label for="lastName">Last name</label>
       <input type="text" name="lastName" id="lastName" required>
   
-      <label for="title">Job title</label>
+      <label class="is-required" for="title">Job title</label>
       <input type="text" name="title" id="title" required>
   
       <label for="Email">Email address:</label>

--- a/templates/partials/_contact-us.html
+++ b/templates/partials/_contact-us.html
@@ -25,7 +25,7 @@
       <label for="lastName">Last name</label>
       <input type="text" name="lastName" id="lastName" required>
 
-      <label for="title">Job title</label>
+      <label class="is-required" for="title">Job title</label>
       <input type="text" name="title" id="title" required>
 
       <label for="Email">Email address:</label>

--- a/templates/partials/_contact-us.html
+++ b/templates/partials/_contact-us.html
@@ -19,19 +19,19 @@
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal" data-js="close-modal-control">Close</button>
     </header>
     <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_5332" style="max-width: 560px;">
-      <label for="firstName">First name</label>
+      <label class="is-required" for="firstName">First name</label>
       <input type="text" name="firstName" id="firstName" required>
 
-      <label for="lastName">Last name</label>
+      <label class="is-required" for="lastName">Last name</label>
       <input type="text" name="lastName" id="lastName" required>
 
       <label class="is-required" for="title">Job title</label>
       <input type="text" name="title" id="title" required>
 
-      <label for="Email">Email address:</label>
+      <label class="is-required" for="Email">Email address:</label>
       <input type="email" name="email" id="email" required>
 
-      <label for="phone">Phone</label>
+      <label class="is-required" for="phone">Phone</label>
       <input type="text" name="phone" id="phone" required>
 
       <label for="Comments_from_lead__c">Comments</label>


### PR DESCRIPTION
## Done

- Job title fields are now mandatory

## QA

- View the site in your web browser at: https://juju-is-575.demos.haus/
- Click on the green "Contact us" button
- Verify the job title fields are mandatory

Bonus points: try to submit the form to make sure it works.

## Issue / Card

Fixes #[WD-19677](https://warthogs.atlassian.net/browse/WD-19677)


[WD-19677]: https://warthogs.atlassian.net/browse/WD-19677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ