### PR TITLE
change juju domain to new docs link

### DIFF
--- a/webapp/docs/search.py
+++ b/webapp/docs/search.py
@@ -20,7 +20,7 @@ RTD_PROJECTS_IO = {
 
 # Domain information mapping, title for chips, weight for relevance
 DOMAIN_INFO = {
-    "canonical-juju.readthedocs-hosted.com": {"title": "Juju", "weight": 0.6},
+    "documentation.ubuntu.com": {"title": "Juju", "weight": 0.6},
     "canonical-terraform-provider-juju.readthedocs-hosted.com": {
         "title": "Terraform Juju",
         "weight": 0.5,


### PR DESCRIPTION
## Done

Updates juju search chip to match the new documentation link (documentation.ubuntu.com)

## QA

- Go to 


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
