### PR TITLE
add missing redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -313,6 +313,7 @@ docs/juju/machine/?: https://documentation.ubuntu.com/juju/3.6/reference/machine
 docs/juju/manage-actions/?: https://documentation.ubuntu.com/juju/3.6/howto/manage-actions/
 docs/juju/manage-applications/?: https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/
 docs/juju/manage-charm-resources/?: https://documentation.ubuntu.com/juju/3.6/howto/manage-charm-resources/
+docs/juju/manage-charms/?: https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/
 docs/juju/manage-charms-or-bundles/?: https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/
 docs/juju/manage-clouds/?: https://documentation.ubuntu.com/juju/3.6/howto/manage-clouds/
 docs/juju/manage-controllers/?: https://documentation.ubuntu.com/juju/3.6/howto/manage-controllers/


### PR DESCRIPTION
## Done

Adds a missing redirect that was missed in the docs migration.

## QA

- Go to https://juju-is-578.demos.haus/docs/juju/manage-charms#heading--update-a-charm
- You should be redirected to https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/15022

