### PR TITLE
fix broken chip domains in docs search

### DIFF
--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -43,8 +43,8 @@
             </a>&nbsp;
             {% set search_path = "search.html" if result.domain in ["pythonlibjuju.readthedocs.io", "ops.readthedocs.io"]
             else "search/" %}
-            <a href="https://{{ result.domain }}/3.6/{{ search_path }}?q={{ query }}" target="_blank" class="p-chip is-inline">
-              <span class="p-chip__value">{{ domain_info.get(result.domain, {}).get("title", result.domain) }}</span>
+            <a href="{{ result.search_url }}" target="_blank" class="p-chip is-inline">
+              <span class="p-chip__value">{{ result.project_name }}</span>
             </a>
           </h5>
           <p>{{ result.short_content }}</p>

--- a/webapp/docs/search.py
+++ b/webapp/docs/search.py
@@ -20,21 +20,52 @@ RTD_PROJECTS_IO = {
 
 # Domain information mapping, title for chips, weight for relevance
 DOMAIN_INFO = {
-    "documentation.ubuntu.com": {"title": "Juju", "weight": 0.6},
+    "documentation.ubuntu.com": {
+        "title": "Juju",
+        "weight": 0.6,
+        "search_url": (
+            "https://documentation.ubuntu.com/juju/3.6/search/?q={query}"
+        ),
+    },
     "canonical-terraform-provider-juju.readthedocs-hosted.com": {
         "title": "Terraform Juju",
         "weight": 0.5,
+        "search_url": (
+            "https://canonical-terraform-provider-juju.readthedocs-hosted.com/"
+            "en/latest/search/?q={query}"
+        ),
     },
-    "pythonlibjuju.readthedocs.io": {"title": "Python Libjuju", "weight": 0.4},
+    "pythonlibjuju.readthedocs.io": {
+        "title": "Python Libjuju",
+        "weight": 0.4,
+        "search_url": (
+            "https://pythonlibjuju.readthedocs.io/en/latest/search.html"
+            "?q={query}"
+        ),
+    },
     "canonical-jaas-documentation.readthedocs-hosted.com": {
         "title": "JAAS",
         "weight": 0.3,
+        "search_url": (
+            "https://canonical-jaas-documentation.readthedocs-hosted.com/"
+            "v3/search/?q={query}"
+        ),
     },
     "canonical-charmcraft.readthedocs-hosted.com": {
         "title": "Charmcraft",
         "weight": 0.2,
+        "search_url": (
+            "https://canonical-charmcraft.readthedocs-hosted.com/en/stable/"
+            "search/?q={query}"
+        ),
     },
-    "ops.readthedocs.io": {"title": "Ops", "weight": 0.1},
+    "ops.readthedocs.io": {
+        "title": "Ops",
+        "weight": 0.1,
+        "search_url": (
+            "https://ops.readthedocs.io/en/stable/search.html?q={query}"
+        ),
+    },
 }
 
 
@@ -151,9 +182,9 @@ def process_and_sort_results(results, query, max_length=200):
         parsed_domain = urlparse(
             result.get("domain", "")
         ).hostname or result.get("domain", "")
-        project_name = DOMAIN_INFO.get(parsed_domain, {}).get(
-            "title", parsed_domain
-        )
+        domain_details = DOMAIN_INFO.get(parsed_domain, {})
+        project_name = domain_details.get("title", parsed_domain)
+        search_url = domain_details.get("search_url", "").format(query=query)
 
         full_content = " ".join(
             block["content"] for block in result.get("blocks", [])
@@ -174,6 +205,7 @@ def process_and_sort_results(results, query, max_length=200):
                 "project_name": project_name,
                 "short_content": short_content,
                 "relevance_score": relevance_score,
+                "search_url": search_url,
             }
         )
 


### PR DESCRIPTION
## Done

Fixes chips on docs search to match updated domains with correct versions.

## QA

- Go to https://juju-is-579.demos.haus/docs and search for something in the "Search documentation" bar
- Click on a chip for each domain to check the search query is correct in the related docs pages
- Check all domains (you will probably need a couple of searches to get all domains, e.g., "remove an application", "jaas", "charmcraft cli"):
  - [ ] juju
  - [ ] charmcraft
  - [ ] terraform juju
  - [ ] python libjuju
  - [ ] ops
  - [ ] jaas
