### PR TITLE
update charmcraft links in juju ecosystem page

### DIFF
--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -399,7 +399,7 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-media-container is-highlighted">
-            <a href="https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/flask/">
+            <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-flask/">
               <img src="https://assets.ubuntu.com/v1/b04cfc1b-Flask.svg" alt="build charms with charmcraft flask" width="100%"
                 height="100%">
             </a>
@@ -410,14 +410,14 @@
         </p>
         <div class="p-equal-height-row__item">
           <hr class="is-muted">
-          <a href="https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/flask/"
+          <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-flask/"
             class="p-button has-icon"><span>Read Charmcraft/Flask docs</span><i class="p-icon--chevron-right"></i></a>
         </div>
       </div>
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-media-container">
-            <a href="https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/write-your-first-kubernetes-charm-for-a-django-app/">
+            <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-django/">
               <img src="https://assets.ubuntu.com/v1/cadf0700-Django.svg" alt="build charms with charmcraft django" width="100%"
                 height="100%">
             </a>
@@ -428,7 +428,7 @@
         </p>
         <div class="p-equal-height-row__item">
           <hr class="is-muted">
-          <a href="https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/write-your-first-kubernetes-charm-for-a-django-app/"
+          <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-django/"
             class="p-button has-icon"><span>Read Charmcraft/Django docs</span><i class="p-icon--chevron-right"></i></a>
         </div>
       </div>
@@ -436,7 +436,7 @@
         <div class="p-equal-height-row__item">
           <div class="p-media-container">
             <a
-              href="https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/write-your-first-kubernetes-charm-for-a-fastapi-app/">
+              href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-fastapi/">
               <img src="https://assets.ubuntu.com/v1/0d40eb55-FastAPI.svg" alt="build charms with charmcaft fast api" width="100%"
                 height="100%">
             </a>
@@ -447,7 +447,7 @@
         </p>
         <div class="p-equal-height-row__item">
           <hr class="is-muted">
-          <a href="https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/write-your-first-kubernetes-charm-for-a-fastapi-app/"
+          <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-fastapi/"
             class="p-button has-icon"><span>Read Charmcaft/FastAPI docs</span><i class="p-icon--chevron-right"></i></a>
         </div>
       </div>
@@ -455,7 +455,7 @@
         <div class="p-equal-height-row__item">
           <div class="p-media-container">
             <a
-              href="https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/write-your-first-kubernetes-charm-for-a-go-app/">
+              href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-go/">
               <img src="https://assets.ubuntu.com/v1/470e39b1-Go.svg" alt="build charms with charmcraft go" width="100%"
                 height="100%">
             </a>
@@ -466,7 +466,7 @@
         </p>
         <div class="p-equal-height-row__item">
           <hr class="is-muted">
-          <a href="https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/write-your-first-kubernetes-charm-for-a-go-app/"
+          <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-go/"
             class="p-button has-icon"><span>Read Charmcraft/Go docs</span><i class="p-icon--chevron-right"></i></a>
         </div>
       </div>


### PR DESCRIPTION
On juju.is/docs, one of the Charmcraft links on the bottom of the page was broken and the remaining three were delayed by redirects. This PR updates all to the latest.