### PR TITLE
Update community and support links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -826,7 +826,7 @@
             </p>
             <hr class="is-muted">
             <p>
-              <a href="/docs/olm">Juju documentation</a>
+              <a href="/docs">Juju documentation</a>
             </p>
             <hr class="is-muted">
             <p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
       <div class="col u-align--center u-hide--medium u-hide--small">
         {{ image(
             url="https://assets.ubuntu.com/v1/8e1d3bf5-juju-hero-juju.is.svg",
-            alt="", 
+            alt="",
             height="366",
             width="450",
             hi_def=True,
@@ -830,10 +830,6 @@
             </p>
             <hr class="is-muted">
             <p>
-              <a href="/docs/sdk">Charm SDK documentation</a>
-            </p>
-            <hr class="is-muted">
-            <p>
               <a href="https://ubuntu.com/engage/kubernetes-operators-explained">What is a software operator?</a>
             </p>
             <hr class="is-muted">
@@ -856,24 +852,24 @@
     <form action="https://ubuntu.com/marketo/submit" method="post" id="mktoForm_5332" style="max-width: 560px;">
       <label class="is-required" for="firstName">First name</label>
       <input type="text" name="firstName" id="firstName" required>
-  
+
       <label class="is-required" for="lastName">Last name</label>
       <input type="text" name="lastName" id="lastName" required>
-  
+
       <label class="is-required" for="title">Job title</label>
       <input type="text" name="title" id="title" required>
-  
+
       <label class="is-required" for="Email">Email address:</label>
       <input type="email" name="email" id="email" required>
-  
+
       <label class="is-required" for="phone">Phone</label>
       <input type="text" name="phone" id="phone" required>
 
       {% include "partials/_country-field.html" %}
-  
+
       <label for="Comments_from_lead__c">Comments</label>
       <textarea name="Comments_from_lead__c" id="Comments_from_lead__c"></textarea>
-  
+
       <label class="p-checkbox">
         <input type="checkbox" class="p-checkbox__input u-no-margin--top" name="canonicalUpdatesOptIn" aria-labelledby="CanonicalUpdatesOptIn" value="yes">
         <span class="p-checkbox__label" id="CanonicalUpdatesOptIn">
@@ -883,9 +879,9 @@
       <p>
         <small>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</small>
       </p>
-  
+
       <button type="submit" class="p-button--positive u-no-margin--bottom" aria-label="Submit">Get in touch</button>
-      
+
       <input type="hidden" name="formid" class="mktoField" value="5332">
       <input type="hidden" name="returnURL" value="https://juju.is/thank-you" />
       <input type="hidden" name="Consent_to_Processing__c" value="yes">
@@ -917,7 +913,7 @@
       }
 
       const targetPanel = document.querySelector(panelLink.getAttribute("href"));
-      
+
       activePanelLink.classList.remove("is-active");
       activePanel.classList.add("u-hide");
       panelLink.classList.add("is-active");


### PR DESCRIPTION
The Community and support section at the very bottom of https://juju.is/ still had a link to the "Charm SDK documentation", even though we disbanded a while ago, and the Juju link pointed to the Juju the lifecycle manager specific documentation instead of the more inclusive Juju ecosystem page docs. This PR fixes both.