### PR TITLE
add blog redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -18,6 +18,8 @@ docs/juju/install-juju: /docs/juju/install-and-manage-the-client
 docs/olm/install-juju: /docs/juju/install-and-manage-the-client
 docs/olm/?: /docs/juju
 docs/olm/(?P<page>.*?): /docs/juju/{page}
+blog/?: https://ubuntu.com/blog
+blog/(?P<blog_title>.*?): https://ubuntu.com/blog/{blog_title}
 
 # Redirect dev docs
 docs/dev(.*?): /docs


### PR DESCRIPTION
## Done

Adds redirects for juju.is/blog to ubuntu.com/blog

## QA

- Go to /blog
  - Make sure it redirects to ubuntu.com/blog
- Go to /blog/model-driven-observability-part-2-juju-topology-metrics
  - Make sure it redirects to ubuntu.com/blog/model-driven-observability-part-2-juju-topology-metrics

