### PR TITLE
docs: fix typo, add new cloud

### DIFF
--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -437,18 +437,18 @@
           <div class="p-media-container">
             <a
               href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-fastapi/">
-              <img src="https://assets.ubuntu.com/v1/0d40eb55-FastAPI.svg" alt="build charms with charmcaft fast api" width="100%"
+              <img src="https://assets.ubuntu.com/v1/0d40eb55-FastAPI.svg" alt="build charms with charmcraft fast api" width="100%"
                 height="100%">
             </a>
           </div>
         </div>
         <p class="p-equal-height-row__item">
-          with Charmcaft/FastAPI
+          with Charmcraft/FastAPI
         </p>
         <div class="p-equal-height-row__item">
           <hr class="is-muted">
           <a href="https://canonical-charmcraft.readthedocs-hosted.com/stable/tutorial/kubernetes-charm-fastapi/"
-            class="p-button has-icon"><span>Read Charmcaft/FastAPI docs</span><i class="p-icon--chevron-right"></i></a>
+            class="p-button has-icon"><span>Read Charmcraft/FastAPI docs</span><i class="p-icon--chevron-right"></i></a>
         </div>
       </div>
       <div class="p-equal-height-row__col">

--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -174,10 +174,10 @@
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju">Microsoft
                 Azure</a>&nbsp;&nbsp;&nbsp;
-              <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>
             </p>
             <p class="p-text--small">
+              <a
+                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju">Oracle OCI</a>&nbsp;&nbsp;&nbsp;
               <a

--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -144,36 +144,38 @@
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-amazon-eks-cloud-and-juju">Amazon
                 EKS</a>&nbsp;&nbsp;&nbsp;
               <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-equinix-metal-cloud-and-juju">Equinix
-                Metal</a>
+                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-canonical-ks-cloud-and-juju">Canonical K8s</a>
             </p>
             <p class="p-text--small">
+              <a
+                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-equinix-metal-cloud-and-juju">Equinix
+                Metal</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju">Google
                 GCE</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-google-gke-cloud-and-juju">Google
-                GKE</a>&nbsp;&nbsp;&nbsp;
+                GKE</a>
+            </p>
+            <p class="p-text--small">
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju">LXD</a>&nbsp;&nbsp;&nbsp;
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju">MAAS</a>&nbsp;&nbsp;&nbsp;
-            </p>
-            <p class="p-text--small">
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-manual-cloud-and-juju/#cloud-manual">Manual</a>&nbsp;&nbsp;&nbsp;
                <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>&nbsp;&nbsp;&nbsp;
+                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microk8s-cloud-and-juju/#cloud-kubernetes-microk8s">MicroK8s</a>
+            </p>
+            <p class="p-text--small">
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-aks-cloud-and-juju/#cloud-kubernetes-aks">Microsoft
                 AKS</a>&nbsp;&nbsp;&nbsp;
-            </p>
-            <p class="p-text--small">
               <a
                 href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju">Microsoft
                 Azure</a>&nbsp;&nbsp;&nbsp;
               <a
-                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>&nbsp;&nbsp;&nbsp;
+                href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju">OpenStack</a>
             </p>
             <p class="p-text--small">
               <a


### PR DESCRIPTION
https://juju.is/docs has a typo where "Charmcraft" is misspelled as "Charmcaft". This PR fixes that.

Juju has a new supported cloud, Canonical K8s (added in this recently merged PR: https://github.com/juju/juju/pull/20242 ). This PR adds this cloud to https://juju.is/docs as well.