### PR TITLE
Fix: Typo in Schema.org article title and improve @id URL

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -12,9 +12,9 @@
 <script type="application/ld+json">
     {
       "@context": "http://schema.org",
-      "@id": "https://juju.is/#article",
+      "@id": "https://juju.is{{ self.meta_path() }}",
       "@type": "Article",
-      "name": "{{ article.title.renderered|safe }}",
+      "name": "{{ article.title.rendered|safe }}",
       "author": {
          "@type": "Person",
          "name": "{{ article.author.name }}"


### PR DESCRIPTION
## Done
Fixed typo renderered to rendered for article.title in Schema.org Article name property
Updated Schema.org Article @id to https://juju.is{{ self.meta_path() }} for better specificity
[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8041
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
