### PR TITLE
update terraform and jaas docs in /docs/search

### DIFF
--- a/templates/docs/juju-ecosystem-docs.html
+++ b/templates/docs/juju-ecosystem-docs.html
@@ -10,14 +10,14 @@
           <a href="https://documentation.ubuntu.com/juju" class="p-tabs__link">Juju Docs</a>
         </li>
         <li class="p-tabs__item">
-          <a href="https://canonical-terraform-provider-juju.readthedocs-hosted.com"
+          <a href="https://documentation.ubuntu.com/terraform-provider-juju"
             class="p-tabs__link">Terraform Juju Docs</a>
         </li>
         <li class="p-tabs__item">
           <a href="https://pythonlibjuju.readthedocs.io" class="p-tabs__link">Python Libjuju Docs</a>
         </li>
         <li class="p-tabs__item">
-          <a href="https://canonical-jaas-documentation.readthedocs-hosted.com" class="p-tabs__link">JAAS
+          <a href="https://documentation.ubuntu.com/jaas" class="p-tabs__link">JAAS
             Docs</a>
         </li>
         <li class="p-tabs__item">
@@ -337,7 +337,7 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-media-container">
-            <a href="https://canonical-terraform-provider-juju.readthedocs-hosted.com">
+            <a href="https://documentation.ubuntu.com/terraform-provider-juju">
               <img src="https://assets.ubuntu.com/v1/96037188-Declaratively.svg" alt="declaratively" width="100%"
                 height="100%">
             </a>
@@ -348,7 +348,7 @@
         </p>
         <div class="p-equal-height-row__item">
           <hr class="is-muted">
-          <a href="https://canonical-terraform-provider-juju.readthedocs-hosted.com"
+          <a href="https://documentation.ubuntu.com/terraform-provider-juju"
             class="p-button has-icon"><span>Read Terraform Juju docs</span><i class="p-icon--chevron-right"></i></a>
         </div>
       </div>
@@ -373,7 +373,7 @@
       <div class="p-equal-height-row__col">
         <div class="p-equal-height-row__item">
           <div class="p-media-container">
-            <a href="https://canonical-jaas-documentation.readthedocs-hosted.com">
+            <a href="https://documentation.ubuntu.com/jaas">
               <img src="https://assets.ubuntu.com/v1/d1ffe118-Enterprise%20style.svg" alt="enterprise style"
                 width="100%" height="100%">
             </a>
@@ -384,7 +384,7 @@
         </p>
         <div class="p-equal-height-row__item">
           <hr class="is-muted">
-          <a href="https://canonical-jaas-documentation.readthedocs-hosted.com"
+          <a href="https://documentation.ubuntu.com/jaas"
             class="p-button has-icon"><span>Read JAAS docs</span><i class="p-icon--chevron-right"></i></a>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Updates `terraform-provider-juju` and `jaas` documentation to new Canonical-hosted docs links
- Updates search results to use new links

## QA

- Go to docs
  - Make sure terraform and jaas links point to new documentation
    - https://documentation.ubuntu.com/terraform-provider-juju
    - https://documentation.ubuntu.com/jaas
- Search for a term (i.e. "terraform" and "jaas")
  - Make sure correct docs links display in search results
  - Make sure chips show correctly

## Issue / Card

Fixes [WD-24163](https://warthogs.atlassian.net/browse/WD-24163)
